### PR TITLE
Optionally use bq for penalize terms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ The Bmax boost component enriches the query with boost and penalize terms.
 
 * `bmax.booster` (boolean) - enable/disable boost term component. Default is `false`.
 * `bmax.booster.boost` (boolean) - enable/disable boost term resolution. Default is `true`.
-* `bmax.booster.penalize` (boolean) - enable/disable penalize term resolution. Default is `true`.
 * `bmax.booster.boost.factor` (float) - boost factor that is multiplied to the boosts given in the `qf` parameter for each query field respectivly, default is `1.0`.
 * `bmax.booster.boost.extra` (String) - comma separated extra boost terms. Great to check new boost term ideas.
-* `bmax.booster.penalize.factor` (float) - Penalize factor that is used as negative weight in the rerank query. Default is `100.0`.
-* `bmax.booster.penalize.docs` (int) - The number of documents to penalize from the begin of the result set. Default is `400`.
+* `bmax.booster.penalize` (boolean) - enable/disable penalize term resolution. Default is `true`.
+* `bmax.booster.penalize.factor` (float) - Penalize factor that is used as negative weight in the penalize query. Default is `100.0`.
+* `bmax.booster.penalize.strategy` (String) - strategy for combining penalize terms with the main query: `rq` - rerank query, `bq`- boost query. Default is `rq`.
+* `bmax.booster.penalize.docs` (int) - The number of documents to penalize from the begin of the result set (rerank query strategy only). Default is `400`.
 * `bmax.booster.penalize.extra` (String) - comma separated extra penalize terms. Great to check new ideas.
+
 
 ### Query parser params
 

--- a/src/main/java/com/s24/search/solr/component/BmaxBoostConstants.java
+++ b/src/main/java/com/s24/search/solr/component/BmaxBoostConstants.java
@@ -1,0 +1,23 @@
+package com.s24.search.solr.component;
+
+public interface BmaxBoostConstants {
+
+    String COMPONENT_NAME = "bmax.booster";
+
+    // params
+    String PENALIZE_EXTRA_TERMS = COMPONENT_NAME + ".penalize.extra";
+    String PENALIZE_DOC_COUNT = COMPONENT_NAME + ".penalize.docs";
+    String PENALIZE_FACTOR = COMPONENT_NAME + ".penalize.factor";
+    String PENALIZE_ENABLE = COMPONENT_NAME + ".penalize";
+    String PENALIZE_FIELDS = COMPONENT_NAME + ".penalize.qf";
+    String PENALIZE_STRATEGY = COMPONENT_NAME + ".penalize.strategy";
+    String VALUE_PENALIZE_STRATEGY_RERANK = "rq";
+    String VALUE_PENALIZE_STRATEGY_BOOST_QUERY = "bq";
+
+    String BOOST_EXTRA_TERMS = COMPONENT_NAME + ".boost.extra";
+    String BOOST_ENABLE = COMPONENT_NAME + ".boost";
+    String BOOST_FACTOR = COMPONENT_NAME + ".boost.factor";
+    String BOOST_FIELDS = COMPONENT_NAME + ".boost.qf";
+    String SYNONYM_ENABLE = COMPONENT_NAME + ".synonyms";
+
+}

--- a/src/main/java/com/s24/search/solr/component/BoostQueryPenalizeStrategy.java
+++ b/src/main/java/com/s24/search/solr/component/BoostQueryPenalizeStrategy.java
@@ -1,0 +1,26 @@
+package com.s24.search.solr.component;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.solr.common.params.DisMaxParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.search.ExtendedDismaxQParser;
+
+import java.util.Locale;
+
+public class BoostQueryPenalizeStrategy extends PenalizeStrategy {
+
+    protected final float penalizeFactor;
+
+    public BoostQueryPenalizeStrategy(final ResponseBuilder rb, final String q, final String penalizeExtraTerms,
+                                      final Analyzer penalizeAnalyzer, final String penalizeFields,
+                                      final float penalizeFactor) {
+        super(rb, q, penalizeExtraTerms, penalizeAnalyzer, penalizeFields);
+        this.penalizeFactor = penalizeFactor;
+    }
+
+    @Override
+    protected void addToQuery(final String penalizeQueryString, final ModifiableSolrParams queryParams) {
+        queryParams.add(DisMaxParams.BQ, "(" + penalizeQueryString + String.format(Locale.US, ")^%.6f", penalizeFactor));
+    }
+}

--- a/src/main/java/com/s24/search/solr/component/PenalizeStrategy.java
+++ b/src/main/java/com/s24/search/solr/component/PenalizeStrategy.java
@@ -1,0 +1,84 @@
+package com.s24.search.solr.component;
+
+import static com.s24.search.solr.component.BmaxBoostConstants.*;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
+import com.s24.search.solr.query.bmax.Terms;
+import com.s24.search.solr.util.BmaxDebugInfo;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.util.SolrPluginUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class PenalizeStrategy {
+
+    private final String q;
+    private final String penalizeExtraTerms;
+    private final Analyzer penalizeAnalyzer;
+    private final String penalizeFields;
+    private final ResponseBuilder rb;
+
+    public PenalizeStrategy(final ResponseBuilder rb, final String q, final String penalizeExtraTerms,
+                            final Analyzer penalizeAnalyzer, final String penalizeFields) {
+        this.q = q;
+        this.penalizeExtraTerms = penalizeExtraTerms;
+        this.penalizeAnalyzer = penalizeAnalyzer;
+        this.penalizeFields = penalizeFields;
+        this.rb = rb;
+    }
+
+    public void apply(final ModifiableSolrParams queryParams) {
+        makePenalizeQueryString().ifPresent(queryString -> addToQuery(queryString, queryParams));
+    }
+
+    protected abstract void addToQuery(String penalizeQueryString, ModifiableSolrParams queryParams);
+
+    protected Optional<String> makePenalizeQueryString() {
+
+
+        final Collection<CharSequence> terms = Terms.collect(q, penalizeAnalyzer);
+
+        // add extra terms
+        if (penalizeExtraTerms != null) {
+            terms.addAll(Sets.newHashSet(Splitter.on(',').omitEmptyStrings().split(penalizeExtraTerms)));
+        }
+
+        // add boosts
+        if (!terms.isEmpty()) {
+
+            // join terms once. save cpu.
+            final String joinedTerms = Joiner.on(" OR ").join(terms);
+
+            // iterate query fields
+            StringBuilder penalizeQueryString = new StringBuilder();
+            Map<String, Float> queryFields = SolrPluginUtils.parseFieldBoosts(penalizeFields);
+            for (Map.Entry<String, Float> field : queryFields.entrySet()) {
+                if (penalizeQueryString.length() > 0) {
+                    penalizeQueryString.append(" OR ");
+                }
+
+                penalizeQueryString.append(field.getKey());
+                penalizeQueryString.append(":(");
+                penalizeQueryString.append(joinedTerms);
+                penalizeQueryString.append(')');
+            }
+
+            // add debug
+            if (rb.isDebugQuery()) {
+                BmaxDebugInfo.add(rb, COMPONENT_NAME + ".penalize.terms", joinedTerms);
+            }
+
+            // append penalizeQueryString query
+            return Optional.of(penalizeQueryString.toString());
+
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/s24/search/solr/component/RerankPenalizeStrategy.java
+++ b/src/main/java/com/s24/search/solr/component/RerankPenalizeStrategy.java
@@ -1,0 +1,31 @@
+package com.s24.search.solr.component;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
+
+import java.util.Locale;
+
+public class RerankPenalizeStrategy extends PenalizeStrategy {
+
+    protected final int penalizeDocs;
+    protected final float penalizeFactor;
+
+    public RerankPenalizeStrategy(final ResponseBuilder rb, final String q, final String penalizeExtraTerms,
+                                  final Analyzer penalizeAnalyzer, final String penalizeFields, final int penalizeDocs,
+                                  final float penalizeFactor) {
+        super(rb, q, penalizeExtraTerms, penalizeAnalyzer, penalizeFields);
+        this.penalizeDocs = penalizeDocs;
+        this.penalizeFactor = penalizeFactor;
+    }
+
+    @Override
+    protected void addToQuery(final String penalizeQueryString, final ModifiableSolrParams queryParams) {
+        queryParams.add(CommonParams.RQ,
+                String.format(Locale.US, "{!rerank reRankQuery=$rqq reRankDocs=%s reRankWeight=%.6f}",
+                penalizeDocs, penalizeFactor));
+        queryParams.add("rqq", penalizeQueryString);
+    }
+
+}

--- a/src/test/java/com/s24/search/solr/component/BmaxBoostTermComponentTest.java
+++ b/src/test/java/com/s24/search/solr/component/BmaxBoostTermComponentTest.java
@@ -1,0 +1,173 @@
+package com.s24.search.solr.component;
+
+import static com.s24.search.solr.component.BmaxBoostConstants.BOOST_ENABLE;
+import static com.s24.search.solr.component.BmaxBoostConstants.PENALIZE_ENABLE;
+import static com.s24.search.solr.component.BmaxBoostConstants.PENALIZE_STRATEGY;
+import static com.s24.search.solr.component.BmaxBoostConstants.SYNONYM_ENABLE;
+import static com.s24.search.solr.component.BmaxBoostConstants.VALUE_PENALIZE_STRATEGY_BOOST_QUERY;
+import static com.s24.search.solr.component.BmaxBoostConstants.VALUE_PENALIZE_STRATEGY_RERANK;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.solr.common.params.DisMaxParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.search.SolrIndexSearcher;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+
+public class BmaxBoostTermComponentTest {
+
+    SolrQueryRequest request = mock(SolrQueryRequest.class);
+    SolrQueryResponse response = mock(SolrQueryResponse.class);
+    SolrIndexSearcher solrIndexSearcher = mock(SolrIndexSearcher.class);
+    IndexSchema schema = mock(IndexSchema.class);
+    FieldType queryParsingFieldType = mock(FieldType.class);
+    FieldType penalizeTermFieldType = mock(FieldType.class);
+
+    ResponseBuilder responseBuilder = new ResponseBuilder(request, response, Collections.emptyList());
+
+    NamedList<String> initArgs = new NamedList<>();
+
+    @Before
+    public void setUp() {
+
+        reset(request);
+        reset(response);
+        reset(solrIndexSearcher);
+
+        when(request.getSearcher()).thenReturn(solrIndexSearcher);
+        when(solrIndexSearcher.getSchema()).thenReturn(schema);
+
+        when(schema.getFieldTypeByName("queryParsingFieldType")).thenReturn(queryParsingFieldType);
+        when(queryParsingFieldType.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
+
+        when(schema.getFieldTypeByName("penalizeTermFieldType")).thenReturn(penalizeTermFieldType);
+        when(penalizeTermFieldType.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
+
+        initArgs.add("queryParsingFieldType", "queryParsingFieldType");
+        initArgs.add("synonymFieldType", "synonymFieldType");
+        initArgs.add("boostTermFieldType", "boostTermFieldType");
+        initArgs.add("penalizeTermFieldType", "penalizeTermFieldType");
+    }
+
+    @Test
+    public void testThatRerankStrategyIsNotAppliedIfRqAlreadyExists() throws Exception {
+
+        BmaxBoostTermComponent component = new BmaxBoostTermComponent();
+        component.init(initArgs);
+        ModifiableSolrParams params = new ModifiableSolrParams();
+        params.set("q", "a b c");
+        params.set("rq", "dummy");
+        params.set(PENALIZE_ENABLE, true);
+        params.set(PENALIZE_STRATEGY, VALUE_PENALIZE_STRATEGY_RERANK);
+        params.set(SYNONYM_ENABLE, false);
+        params.set(BOOST_ENABLE, false);
+        params.set(DisMaxParams.QF, "field1 field2^3");
+        when(request.getParams()).thenReturn(params);
+
+        component.prepareInternal(responseBuilder);
+        ArgumentCaptor<SolrParams> argument = ArgumentCaptor.forClass(SolrParams.class);
+        verify(request).setParams(argument.capture());
+
+        Assert.assertThat(argument.getValue().getParams("rq"),
+                CoreMatchers.equalTo(new String[] {"dummy"}) );
+
+
+    }
+
+    @Test
+    public void testThatRerankStrategyIsApplied() throws Exception {
+
+        BmaxBoostTermComponent component = new BmaxBoostTermComponent();
+        component.init(initArgs);
+        ModifiableSolrParams params = new ModifiableSolrParams();
+        params.set("q", "a b c");
+        params.set(PENALIZE_ENABLE, true);
+        params.set(PENALIZE_STRATEGY, VALUE_PENALIZE_STRATEGY_RERANK);
+        params.set(SYNONYM_ENABLE, false);
+        params.set(BOOST_ENABLE, false);
+        params.set(DisMaxParams.QF, "field1 field2^3");
+        when(request.getParams()).thenReturn(params);
+
+        component.prepareInternal(responseBuilder);
+
+        ArgumentCaptor<SolrParams> argument = ArgumentCaptor.forClass(SolrParams.class);
+        verify(request).setParams(argument.capture());
+
+        Assert.assertThat(argument.getValue().getParams("rq"),
+                CoreMatchers.equalTo(
+                        new String[] {"{!rerank reRankQuery=$rqq reRankDocs=400 reRankWeight=-100.000000}"}) );
+
+        // 'a' was removed from q as it is a stopword in StandardAnalyzer
+        Assert.assertThat(argument.getValue().getParams("rqq"),
+                CoreMatchers.equalTo(new String[] {"field1:(b OR c) OR field2:(b OR c)"}) );
+
+
+    }
+
+    @Test
+    public void testThatBoostQueryStrategyIsApplied() throws Exception {
+
+        BmaxBoostTermComponent component = new BmaxBoostTermComponent();
+        component.init(initArgs);
+        ModifiableSolrParams params = new ModifiableSolrParams();
+        params.set("q", "a b c");
+        params.set(PENALIZE_ENABLE, true);
+        params.set(PENALIZE_STRATEGY, VALUE_PENALIZE_STRATEGY_BOOST_QUERY);
+        params.set(SYNONYM_ENABLE, false);
+        params.set(BOOST_ENABLE, false);
+        params.set(DisMaxParams.QF, "field1 field2^3");
+        when(request.getParams()).thenReturn(params);
+
+        component.prepareInternal(responseBuilder);
+
+        ArgumentCaptor<SolrParams> argument = ArgumentCaptor.forClass(SolrParams.class);
+        verify(request).setParams(argument.capture());
+
+        Assert.assertThat(argument.getValue().getParams("bq"),
+                CoreMatchers.equalTo(new String[] {"(field1:(b OR c) OR field2:(b OR c))^-100.000000"}) );
+
+    }
+
+    @Test
+    public void testThatBoostQueryStrategyIsNotAppliedIfBqAlreadyExists() throws Exception {
+
+        BmaxBoostTermComponent component = new BmaxBoostTermComponent();
+        component.init(initArgs);
+        ModifiableSolrParams params = new ModifiableSolrParams();
+        params.set("q", "a b c");
+        params.set("bq", "dummy");
+        params.set(PENALIZE_ENABLE, false);
+        params.set(PENALIZE_STRATEGY, VALUE_PENALIZE_STRATEGY_BOOST_QUERY);
+        params.set(SYNONYM_ENABLE, false);
+        params.set(BOOST_ENABLE, true);
+        params.set(DisMaxParams.QF, "field1 field2^3");
+        when(request.getParams()).thenReturn(params);
+
+        component.prepareInternal(responseBuilder);
+        ArgumentCaptor<SolrParams> argument = ArgumentCaptor.forClass(SolrParams.class);
+        verify(request).setParams(argument.capture());
+
+        Assert.assertThat(argument.getValue().getParams("bq"),
+                CoreMatchers.equalTo(new String[] {"dummy"}) );
+
+
+    }
+
+
+}


### PR DESCRIPTION
Implements #10. The query type for the penalize terms is controlled by request parameter `bmax.booster.penalize.strategy` (`rq`- rerank (default), bq - boost query)

