### PR TITLE
Enable pf/pf2/pf3

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ and the following standard url parameters can be used:
 * `bf` (string) – [additive boost functions](https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Thebf_BoostFunctions_Parameter)
 * `tie` (string) – [the dismax tie breaker](https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Thetie_TieBreaker_Parameter), default is `0.0`.
 * `boost` (string) – [multiplicative boost functions](https://lucene.apache.org/solr/guide/6_6/the-extended-dismax-query-parser.html#TheExtendedDisMaxQueryParser-TheboostParameter)
+* `pf` (string) - [the phrase fields](https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Thepf_PhraseFields_Parameter)
+* `ps` (string) - [the phrase slop for pf (default for pf2/pf3)](https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theps_PhraseSlop_Parameter)
+* `pf2` (string) - [the bigram phrase fields](https://lucene.apache.org/solr/guide/6_6/the-extended-dismax-query-parser.html#TheExtendedDisMaxQueryParser-Thepf2Parameter)
+* `ps2` (string) - [the phrase slop for pf2](https://lucene.apache.org/solr/guide/6_6/the-extended-dismax-query-parser.html#TheExtendedDisMaxQueryParser-Theps2Parameter)
+* `pf3` (string) - [the trigram phrase fields](https://lucene.apache.org/solr/guide/6_6/the-extended-dismax-query-parser.html#TheExtendedDisMaxQueryParser-Theps3Parameter)
+* `ps3` (string) - [the phrase slop for pf3](https://lucene.apache.org/solr/guide/6_6/the-extended-dismax-query-parser.html#TheExtendedDisMaxQueryParser-Theps3Parameter)
+* `phrase.tie` (float) - A tie breaker that is used when aggregating pf,pf2,pf3 queries. Defaults to the value of `tie`
 
 To fine tune or debug your query, use the following extra arguments:
 
@@ -146,6 +153,8 @@ The bmax query parser utilizes the `edismax` query parser to build it's query. I
 * `bq` – the boost query (additive)
 * `bf` – boost functions (additive)
 * `boost` – boost functions (multiplicative)
+* `pf,ps,pf2,ps2,pf3,ps3` – phrase boosts (additive). Note that the scores from these boosts are added up per type (pf,pf2,pf3) and field but dismax'ed between types and fields.
+    Set `phrase.tie=1.0` if you want the standard edismax behaviour and also add up the scores between fields and types.
 
 Rerank queries are realized through the default Solr rerank postfilter. Query parsing
 is done in 3 steps:

--- a/src/main/java/com/s24/search/solr/query/bmax/BmaxLuceneQueryBuilder.java
+++ b/src/main/java/com/s24/search/solr/query/bmax/BmaxLuceneQueryBuilder.java
@@ -4,8 +4,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
@@ -15,12 +20,15 @@ import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.valuesource.ProductFloatFunction;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.QueryBuilder;
 import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.search.FieldParams;
 import org.apache.solr.search.SolrCache;
 
 import com.s24.search.solr.query.bmax.BmaxQuery.BmaxTerm;
@@ -129,16 +137,19 @@ public class BmaxLuceneQueryBuilder {
       // add boost queries
       if (boostQueries != null) {
          for (Query f : boostQueries) {
-            bq.add(f, BooleanClause.Occur.SHOULD);
+            bq.add(f, Occur.SHOULD);
          }
       }
 
       // add additive boost function
       if (additiveBoostFunctions != null) {
          for (Query f : additiveBoostFunctions) {
-            bq.add(f, BooleanClause.Occur.SHOULD);
+            bq.add(f, Occur.SHOULD);
          }
       }
+
+      // add phrase boost
+      getPhraseFieldQueries().ifPresent(pfQuery -> bq.add(pfQuery, Occur.SHOULD));
 
       // done
       return bq.build();
@@ -248,9 +259,122 @@ public class BmaxLuceneQueryBuilder {
 
       // set boost
       if (boost > 0f) {
-         return new BoostQuery(termsquery, boost);
+         return withBoostFactor(termsquery, boost);
       }
 
       return termsquery;
    }
+
+   protected Optional<Query> getPhraseFieldQueries()  {
+
+      // sloppy phrase queries for proximity
+      final List<FieldParams> allPhraseFields = bmaxquery.getAllPhraseFields();
+
+      if (allPhraseFields.size() > 0) {
+
+         final List<BmaxTerm> bmaxTerms = bmaxquery.getTerms();
+
+         if (bmaxTerms.size() > 1) { // it's a phrase
+
+            final List<CharSequence> terms = bmaxTerms.stream().map(BmaxTerm::getTerm).collect(Collectors.toList());
+            final List<Query> disjuncts = new LinkedList<>();
+
+            final QueryBuilder queryBuilder = new QueryBuilder(schema.getQueryAnalyzer());
+
+            final Map<Integer, List<String>> shingles = new HashMap<>(2);
+            String queryStringAsPhrase = null;
+
+            for (final FieldParams fieldParams : allPhraseFields) {
+
+               final int n = fieldParams.getWordGrams();
+               final int slop = fieldParams.getSlop();
+               final String fieldname = fieldParams.getField();
+
+               if (n == 0) { // entire phrase
+
+
+                  if (queryStringAsPhrase == null) {
+                     // We don't have the entire query string as a phrase yet
+                     // (= this is the first field in the allPhraseFields loop)
+                     queryStringAsPhrase = terms.stream().collect(Collectors.joining(" "));
+
+                  }
+                  final Query pq = queryBuilder.createPhraseQuery(fieldname, queryStringAsPhrase, slop);
+                  if (pq != null) {
+                     disjuncts.add(withBoostFactor(pq, fieldParams.getBoost()));
+                  }
+
+               } else if (n <= terms.size()) { // pf2 or pf3
+
+                  // get/create field-independent bi-gram or tri-gram strings
+                  final List<String> shinglesN = shingles.computeIfAbsent(n, nGramSize -> {
+
+                     final List<String> newShingles = new LinkedList<>();
+
+                     for (int i = 0, lenI = terms.size() - nGramSize + 1; i < lenI; i++) {
+
+
+                        final StringBuilder sb = new StringBuilder();
+
+                        for (int j = i, lenJ = j + n; j < lenJ; j++) {
+                           if (sb.length() > 0) {
+                              sb.append(' ');
+                           }
+                           sb.append(terms.get(j));
+                        }
+                        newShingles.add(sb.toString());
+                     }
+
+                     return newShingles;
+                  });
+
+                  // map bi-gram/tri-gram strings to phrase queries
+                  final List<Query> nGramQueries = shinglesN.stream()
+                          .map(nGram ->  queryBuilder.createPhraseQuery(fieldname, nGram, slop))
+                          .filter(q -> q != null)
+                          .collect(Collectors.toList());
+
+
+                  switch (nGramQueries.size()) {
+                     case 0: break;
+                     case 1: {
+                        disjuncts.add(withBoostFactor(nGramQueries.get(0), fieldParams.getBoost()));
+                        break;
+
+                     }
+                     default:
+                        // If we have > 1 n-gram phrase for this field, aggregate their scores using
+                        // a BooleanQuery with all clauses being optional
+                        final BooleanQuery.Builder builder = new BooleanQuery.Builder();
+                        builder.setDisableCoord(true);
+                        builder.setMinimumNumberShouldMatch(1);
+
+                        for (final Query nGramQuery : nGramQueries) {
+                           builder.add(nGramQuery, BooleanClause.Occur.SHOULD);
+                        }
+
+                        disjuncts.add(withBoostFactor(builder.build(), fieldParams.getBoost()));
+                  }
+               }
+            }
+
+            switch (disjuncts.size()) {
+               case 0: break;
+               case 1: return Optional.of(disjuncts.get(0));
+               default :
+                  return Optional.of(new DisjunctionMaxQuery(disjuncts, bmaxquery.getPhraseBoostTieBreaker()));
+            }
+         }
+
+
+      }
+
+      return Optional.empty();
+   }
+
+   public static Query withBoostFactor(final Query query, float boostFactor) {
+      return boostFactor == 1f ? query : new BoostQuery(query, boostFactor);
+   }
+
+
 }

--- a/src/main/java/com/s24/search/solr/query/bmax/BmaxQuery.java
+++ b/src/main/java/com/s24/search/solr/query/bmax/BmaxQuery.java
@@ -1,6 +1,7 @@
 package com.s24.search.solr.query.bmax;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -8,6 +9,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.solr.search.FieldParams;
 
 /**
  * POJO for query data used in bmax
@@ -17,7 +19,7 @@ import com.google.common.collect.Sets;
 public class BmaxQuery {
 
    // terms with their collected synonyms and subopics
-   private final Collection<BmaxTerm> terms = Lists.newArrayList();
+   private final List<BmaxTerm> terms = Lists.newArrayList();
 
    // fields to query and their boosts
    private final Map<String, Float> fieldsAndBoosts = Maps.newHashMap();
@@ -29,8 +31,11 @@ public class BmaxQuery {
    private boolean subtopicEnabled = true;
    private float subtopicBoost = 0.01f;
    private float tieBreakerMultiplier = 0.0f;
+   // tie breaker for pf boost queries
+   private float phraseBoostTieBreaker = tieBreakerMultiplier;
    private boolean inspectTerms = false;
    private boolean buildTermsInspectionCache = false;
+   private List<FieldParams> allPhraseFields;
 
    public Map<String, Float> getFieldsAndBoosts() {
       return fieldsAndBoosts;
@@ -72,7 +77,7 @@ public class BmaxQuery {
       this.subtopicBoost = subtopicBoost;
    }
 
-   public Collection<BmaxTerm> getTerms() {
+   public List<BmaxTerm> getTerms() {
       return terms;
    }
 
@@ -82,6 +87,22 @@ public class BmaxQuery {
 
    public void setTieBreakerMultiplier(float tieBreakerMultiplier) {
       this.tieBreakerMultiplier = tieBreakerMultiplier;
+   }
+
+   public float getPhraseBoostTieBreaker() {
+      return phraseBoostTieBreaker;
+   }
+
+   public void setPhraseBoostTieBreaker(float phraseBoostTieBreaker) {
+      this.phraseBoostTieBreaker = phraseBoostTieBreaker;
+   }
+
+   public List<FieldParams> getAllPhraseFields() {
+      return allPhraseFields;
+   }
+
+   public void setAllPhraseFields(List<FieldParams> allPhraseFields) {
+      this.allPhraseFields = allPhraseFields;
    }
 
    public boolean isInspectTerms() {

--- a/src/main/java/com/s24/search/solr/query/bmax/BmaxQueryParser.java
+++ b/src/main/java/com/s24/search/solr/query/bmax/BmaxQueryParser.java
@@ -2,12 +2,28 @@ package com.s24.search.solr.query.bmax;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.QueryBuilder;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.common.params.SolrParams;
@@ -15,6 +31,7 @@ import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.search.ExtendedDismaxQParser;
+import org.apache.solr.search.FieldParams;
 import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.util.SolrPluginUtils;
@@ -44,6 +61,7 @@ public class BmaxQueryParser extends ExtendedDismaxQParser {
    public static final String PARAM_TIE = DisMaxParams.TIE;
    public static final String PARAM_INSPECT_TERMS = "bmax.inspect";
    public static final String PARAM_BUILD_INSPECT_TERMS = "bmax.inspect.build";
+   public static final String PARAM_PHRASE_BOOST_TIE = "phrase.tie";
 
    private static final String WILDCARD = "*:*";
 
@@ -193,7 +211,38 @@ public class BmaxQueryParser extends ExtendedDismaxQParser {
       query.setSynonymBoost(params.getFloat(PARAM_SYNONYM_BOOST, 0.1f));
       query.setSubtopicEnabled(params.getBool(PARAM_SUBTOPIC_ENABLE, true));
       query.setSubtopicBoost(params.getFloat(PARAM_SUBTOPIC_BOOST, 0.01f));
-      query.setTieBreakerMultiplier(params.getFloat(PARAM_TIE, 0.00f));
+
+      final float tieBreaker = params.getFloat(PARAM_TIE, 0.00f);
+      query.setTieBreakerMultiplier(tieBreaker);
+      query.setPhraseBoostTieBreaker(params.getFloat(PARAM_PHRASE_BOOST_TIE, tieBreaker));
+
+      // Phrase slop array
+      final int pslop[] = new int[4];
+      pslop[0] = params.getInt(DisMaxParams.PS, 0);
+      pslop[2] = params.getInt(DisMaxParams.PS2, pslop[0]);
+      pslop[3] = params.getInt(DisMaxParams.PS3, pslop[0]);
+
+      final List<FieldParams> phraseFields = SolrPluginUtils
+              .parseFieldBoostsAndSlop(params.getParams(DisMaxParams.PF), 0, pslop[0]);
+      final List<FieldParams> phraseFields2 = SolrPluginUtils
+              .parseFieldBoostsAndSlop(params.getParams(DisMaxParams.PF2), 2, pslop[2]);
+      final List<FieldParams> phraseFields3 = SolrPluginUtils
+              .parseFieldBoostsAndSlop(params.getParams(DisMaxParams.PF3), 3, pslop[3]);
+
+      final int numPhraseFields = phraseFields.size() + phraseFields2.size() + phraseFields3.size();
+
+
+      final List<FieldParams> allPhraseFields;
+      if (numPhraseFields == 0) {
+         allPhraseFields = Collections.emptyList();
+      } else {
+         allPhraseFields = new ArrayList<>(numPhraseFields);
+         allPhraseFields.addAll(phraseFields);
+         allPhraseFields.addAll(phraseFields2);
+         allPhraseFields.addAll(phraseFields3);
+      }
+      query.setAllPhraseFields(allPhraseFields);
+
       query.setInspectTerms(params.getBool(PARAM_INSPECT_TERMS, false));
       query.setBuildTermsInspectionCache(params.getBool(PARAM_BUILD_INSPECT_TERMS, false));
 

--- a/src/main/java/com/s24/search/solr/query/bmax/BmaxQueryParser.java
+++ b/src/main/java/com/s24/search/solr/query/bmax/BmaxQueryParser.java
@@ -3,27 +3,14 @@ package com.s24.search.solr.query.bmax;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.BoostQuery;
-import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.QueryBuilder;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.common.params.SolrParams;

--- a/src/test/java/com/s24/search/solr/query/bmax/AbstractLuceneQueryTest.java
+++ b/src/test/java/com/s24/search/solr/query/bmax/AbstractLuceneQueryTest.java
@@ -1,0 +1,414 @@
+package com.s24.search.solr.query.bmax;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AbstractLuceneQueryTest {
+
+   public ClauseMatcher tq(Occur occur, float boost, String field, String text) {
+      return c(occur, tq(boost, field, text));
+   }
+
+   public ClauseMatcher tq(Occur occur, String field, String text) {
+      return c(occur, tq(field, text));
+   }
+
+   public static TQMatcher tq(float boost, String field, String text) {
+      return new TQMatcher(boost, field, text);
+   }
+
+   public static TQMatcher tq(String field, String text) {
+      return tq(1f, field, text);
+   }
+   
+   public static BQMatcher bq(float boost, int mm, ClauseMatcher... clauses) {
+      return new BQMatcher(boost, mm, clauses);
+   }
+
+   public static BQMatcher bq(float boost, ClauseMatcher... clauses) {
+      return new BQMatcher(boost, 0, clauses);
+   }
+
+   public static BQMatcher bq(ClauseMatcher... clauses) {
+      return bq(1f, clauses);
+   }
+
+   public static PhraseQueryMatcher phrase(float boost, String field, int slop, String... terms) {
+       return new PhraseQueryMatcher(boost, field, terms, slop);
+   }
+   
+   public ClauseMatcher all(Occur occur) {
+       return c(occur, all());
+   }
+   
+   public AllDocsQueryMatcher all() {return  new AllDocsQueryMatcher(); }
+
+   public ClauseMatcher bq(Occur occur, float boost, int mm, ClauseMatcher... clauses) {
+      return c(occur, bq(boost, mm, clauses));
+   }
+
+   public ClauseMatcher bq(Occur occur, float boost, ClauseMatcher... clauses) {
+      return c(occur, bq(boost, clauses));
+   }
+
+   public ClauseMatcher bq(Occur occur, ClauseMatcher... clauses) {
+      return c(occur, bq(clauses));
+   }
+
+   @SafeVarargs
+   public static DMQMatcher dmq(float boost, float tieBreaker, TypeSafeMatcher<? extends Query>... disjuncts) {
+      return new DMQMatcher(boost, tieBreaker, disjuncts);
+   }
+
+   @SafeVarargs
+   public static final DMQMatcher dmq(float boost, TypeSafeMatcher<? extends Query>... disjuncts) {
+      return dmq(boost, 0.0f, disjuncts);
+   }
+
+   @SafeVarargs
+   public static final DMQMatcher dmq(TypeSafeMatcher<? extends Query>... disjuncts) {
+      return dmq(1f, 0.0f, disjuncts);
+   }
+
+   @SafeVarargs
+   public final ClauseMatcher dmq(Occur occur, float boost, float tieBreaker,
+                                  TypeSafeMatcher<? extends Query>... disjuncts) {
+      return c(occur, dmq(boost, tieBreaker, disjuncts));
+   }
+
+   @SafeVarargs
+   public final ClauseMatcher dmq(Occur occur, float boost, TypeSafeMatcher<? extends Query>... disjuncts) {
+      return c(occur, dmq(boost, disjuncts));
+   }
+
+   @SafeVarargs
+   public final ClauseMatcher dmq(Occur occur, TypeSafeMatcher<? extends Query>... disjuncts) {
+      return c(occur, dmq(disjuncts));
+   }
+
+   public static ClauseMatcher c(Occur occur, TypeSafeMatcher<? extends Query> queryMatcher) {
+      return new ClauseMatcher(occur, queryMatcher);
+   }
+
+   static class ClauseMatcher extends TypeSafeMatcher<BooleanClause> {
+
+      Occur occur;
+      TypeSafeMatcher<? extends Query> queryMatcher;
+
+      public ClauseMatcher(Occur occur, TypeSafeMatcher<? extends Query> queryMatcher) {
+         this.occur = occur;
+         this.queryMatcher = queryMatcher;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+         description.appendText("occur: " + occur.name() + ", query: ");
+         queryMatcher.describeTo(description);
+      }
+
+      @Override
+      protected boolean matchesSafely(BooleanClause clause) {
+         return clause.getOccur() == occur && queryMatcher.matches(clause.getQuery());
+      }
+
+   }
+
+    static class DMQMatcher extends TypeSafeMatcher<Query> {
+        float boost;
+        float tieBreaker;
+        TypeSafeMatcher<? extends Query>[] disjuncts;
+
+        @SafeVarargs
+        public DMQMatcher(float boost, float tieBreaker, TypeSafeMatcher<? extends Query>... disjuncts) {
+            super((boost == 1f) ? DisjunctionMaxQuery.class : BoostQuery.class);
+            this.boost = boost;
+            this.tieBreaker = tieBreaker;
+            this.disjuncts = disjuncts;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("DMQ: tie=" + tieBreaker + ", boost=" + boost + ", ");
+            description.appendList("disjuncts:[", ",\n", "]", Arrays.asList(disjuncts));
+        }
+
+        @Override
+        protected boolean matchesSafely(Query query) {
+
+            DisjunctionMaxQuery dmq;
+
+            if (query instanceof BoostQuery) {
+                BoostQuery boostQuery = (BoostQuery) query;
+                if (boostQuery.getBoost() != boost) {
+                    return false;
+                } else {
+                    dmq = (DisjunctionMaxQuery) boostQuery.getQuery();
+                }
+            } else {
+                if (boost != 1f) {
+                    return false;
+                } else {
+                    dmq = (DisjunctionMaxQuery) query;
+                }
+            }
+
+            return matchDisjunctionMaxQuery(dmq);
+
+        }
+
+        protected boolean matchDisjunctionMaxQuery(DisjunctionMaxQuery dmq) {
+
+            if (tieBreaker != dmq.getTieBreakerMultiplier()) {
+                return false;
+            }
+
+            List<Query> dmqDisjuncts = dmq.getDisjuncts();
+            if (dmqDisjuncts == null || dmqDisjuncts.size() != disjuncts.length) {
+                return false;
+            }
+
+            for (TypeSafeMatcher<? extends Query> disjunct : disjuncts) {
+                boolean found = false;
+                for (Query q : dmqDisjuncts) {
+                    found = disjunct.matches(q);
+                    if (found) {
+                        break;
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+
+            }
+            return true;
+        }
+    }
+   
+    class AllDocsQueryMatcher extends TypeSafeMatcher<Query> {
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("AllDocs");
+        }
+
+        @Override
+        protected boolean matchesSafely(Query item) {
+            return MatchAllDocsQuery.class.isAssignableFrom(item.getClass());
+        }
+       
+    }
+
+    static class BQMatcher extends TypeSafeMatcher<Query> {
+
+        ClauseMatcher[] clauses;
+        int mm;
+        float boost;
+
+        public BQMatcher(float boost, int mm, ClauseMatcher... clauses) {
+            super((boost == 1f) ? BooleanQuery.class : BoostQuery.class);
+            this.clauses = clauses;
+            this.boost = boost;
+            this.mm = mm;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("BQ: mm=" + mm + ", boost=" + boost + ", ");
+            description.appendList("clauses:[", ",\n", "]", Arrays.asList(clauses));
+        }
+
+        @Override
+        protected boolean matchesSafely(Query query) {
+
+            BooleanQuery bq = null;
+
+            if (query instanceof BoostQuery) {
+
+                Query boostedQuery = ((BoostQuery) query).getQuery();
+                if (!(boostedQuery instanceof BooleanQuery)) {
+                    return false;
+                }
+
+                if (((BoostQuery) query).getBoost() != boost) {
+                    return false;
+                }
+
+                bq = (BooleanQuery) boostedQuery;
+
+            } else if (!(query instanceof BooleanQuery)) {
+                return false;
+            } else {
+                if (boost != 1f) {
+                    return false;
+                }
+                bq = (BooleanQuery) query;
+            }
+
+            return matchBooleanQuery(bq);
+
+        }
+
+        protected boolean matchBooleanQuery(BooleanQuery bq) {
+
+            if (mm != bq.getMinimumNumberShouldMatch()) {
+                return false;
+            }
+
+            List<BooleanClause> bqClauses = bq.clauses();
+            if (bqClauses == null || bqClauses.size() != clauses.length) {
+                return false;
+            }
+
+            for (int i = 0; i < clauses.length; i++) {
+
+                boolean found = false;
+                for (BooleanClause clause : bqClauses) {
+                    found = clauses[i].matches(clause);
+                    if (found) {
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    return false;
+                }
+
+            }
+            return true;
+        }
+
+    }
+
+    static class PhraseQueryMatcher extends TypeSafeMatcher<Query> {
+
+       final String field;
+       final int slop;
+       final String[] terms;
+       final float boost;
+
+       public PhraseQueryMatcher(float boost, final String field, final String[] terms, final int slop) {
+           super((boost == 1f) ? PhraseQuery.class : BoostQuery.class);
+
+           this.field = field;
+           this.slop = slop;
+           this.terms = terms;
+           this.boost = boost;
+
+       }
+
+       @Override
+       protected boolean matchesSafely(Query query) {
+
+           PhraseQuery pq = null;
+
+           if (query instanceof BoostQuery) {
+
+               Query boostedQuery = ((BoostQuery) query).getQuery();
+               if (!(boostedQuery instanceof PhraseQuery)) {
+                   return false;
+               }
+
+               if (((BoostQuery) query).getBoost() != boost) {
+                   return false;
+               }
+
+               pq = (PhraseQuery) boostedQuery;
+
+           } else if (!(query instanceof PhraseQuery)) {
+               return false;
+           } else {
+               if (boost != 1f) {
+                   return false;
+               }
+               pq = (PhraseQuery) query;
+           }
+
+           return matchesPhraseQuery(pq);
+
+       }
+
+        protected boolean matchesPhraseQuery(PhraseQuery item) {
+            final Term[] phraseTerms = item.getTerms();
+            if (phraseTerms.length != terms.length || slop != item.getSlop()) {
+                return false;
+            }
+            for (int i = 0; i < terms.length; i++) {
+                if (!phraseTerms[i].equals(new Term(field, terms[i]))) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+
+
+       @Override
+       public void describeTo(Description description) {
+           description.appendText("PQ: " + field + ":\"" + Arrays.stream(terms).collect(Collectors.joining(" "))  + "\"~" + slop + " ^" + boost);
+       }
+    }
+
+    static class TQMatcher extends TypeSafeMatcher<Query> {
+
+      final String field;
+      final String text;
+      final float boost;
+
+      public TQMatcher(float boost, String field, String text) {
+         super(TermQuery.class);
+         this.field = field;
+         this.text = text;
+         this.boost = boost;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+         description.appendText("TQ field: " + field + ", text: " + text + ", boost: " + boost);
+
+      }
+
+      @Override
+      protected boolean matchesSafely(Query query) {
+
+          if (query instanceof BoostQuery) {
+
+              BoostQuery boostQuery = (BoostQuery) query;
+
+              Query boostedQuery = boostQuery.getQuery();
+              if (boostedQuery instanceof TermQuery) {
+                  Term term = ((TermQuery) query).getTerm();
+                  return field.equals(term.field())
+                          && text.equals(term.text())
+                          && boostQuery.getBoost() == boost;
+              } else {
+                  return false;
+              }
+          } else if (query instanceof TermQuery) {
+              Term term = ((TermQuery) query).getTerm();
+              return field.equals(term.field())
+                      && text.equals(term.text())
+                      && boost == 1f;
+          } else {
+              return false;
+          }
+
+      }
+
+   }
+
+}

--- a/src/test/java/com/s24/search/solr/query/bmax/BmaxLuceneQueryBuilderTest.java
+++ b/src/test/java/com/s24/search/solr/query/bmax/BmaxLuceneQueryBuilderTest.java
@@ -1,12 +1,50 @@
 package com.s24.search.solr.query.bmax;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
+import static com.s24.search.solr.query.bmax.AbstractLuceneQueryTest.*;
+
+import com.s24.search.solr.query.bmax.BmaxQuery.BmaxTerm;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.schema.SchemaField;
+import org.apache.solr.search.FieldParams;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class BmaxLuceneQueryBuilderTest {
+
+   IndexSchema schema = Mockito.mock(IndexSchema.class);
+   FieldType fieldType = Mockito.mock(FieldType.class);
+
+   SchemaField schemaField1 = new SchemaField("field1", fieldType);
+   SchemaField schemaField2 = new SchemaField("field2", fieldType);
+   SchemaField schemaField3 = new SchemaField("field3", fieldType);
+
+   @Before
+   public void setUp() {
+      Mockito.reset(schema, fieldType);
+      when(schema.getField("field1")).thenReturn(schemaField1);
+      when(schema.getField("field2")).thenReturn(schemaField2);
+      when(schema.getField("field3")).thenReturn(schemaField3);
+      when(schema.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
+      when(fieldType.getQueryAnalyzer()).thenReturn(new StandardAnalyzer());
+   }
 
    @Test
    public void testBuildingBmaxLuceneQueryWorksOnSimpleBmaxQuery() throws Exception {
@@ -20,4 +58,55 @@ public class BmaxLuceneQueryBuilderTest {
 
    }
 
+   @Test
+   public void testPhraseBoost() throws Exception {
+
+
+      BmaxQuery bmaxQuery = new BmaxQuery();
+      bmaxQuery.getFieldsAndBoosts().put("field1", 10f);
+
+      bmaxQuery.getTerms().addAll(Arrays.asList(new BmaxTerm("t1"), new BmaxTerm("t2"), new BmaxTerm("t3"),
+              new BmaxTerm("t4")));
+      bmaxQuery.setTieBreakerMultiplier(0.01f);
+
+      bmaxQuery.setPhraseBoostTieBreaker(0.3f);
+      bmaxQuery.setAllPhraseFields(
+              Arrays.asList(new FieldParams("field1", 0, 0, 2f), new FieldParams("field2", 2, 2, 1f),
+                      new FieldParams("field1", 3, 0, 3f)));
+
+      Query query = new BmaxLuceneQueryBuilder(bmaxQuery)
+              .withSchema(schema)
+              .build();
+      assertTrue(query instanceof BooleanQuery);
+
+      BooleanQuery bq = (BooleanQuery) query;
+      
+      final List<DisjunctionMaxQuery> pfQueries = bq.clauses().stream()
+              .filter(clause -> (clause.getOccur() == BooleanClause.Occur.SHOULD))
+              .filter(clause -> clause.getQuery() instanceof DisjunctionMaxQuery)
+              .map(clause -> (DisjunctionMaxQuery) clause.getQuery())
+              .filter(dmq -> dmq.getTieBreakerMultiplier() == 0.3f)
+              .collect(Collectors.toList());
+      assertEquals(1, pfQueries.size());
+
+      assertThat(pfQueries.get(0),
+              dmq(1f, 0.3f,
+                      phrase(2f, "field1", 0, "t1", "t2", "t3", "t4"),
+                      bq(1f, 1,
+                              c(BooleanClause.Occur.SHOULD, phrase(1f, "field2", 2, "t1", "t2")),
+                              c(BooleanClause.Occur.SHOULD, phrase(1f, "field2", 2, "t2", "t3")),
+                              c(BooleanClause.Occur.SHOULD, phrase(1f, "field2", 2, "t3", "t4")))
+
+                      ,
+                      bq(3f, 1,
+                              c(BooleanClause.Occur.SHOULD, phrase(1f, "field1", 0, "t1", "t2", "t3")),
+                              c(BooleanClause.Occur.SHOULD, phrase(1f, "field1", 0, "t2", "t3", "t4"))
+
+
+
+              )));
+
+
+
+   }
 }


### PR DESCRIPTION
The Bmax query parser should provide phrase boosting similar to Edismax pf/pf2/pf3. This pull request enables this features. In addition to the Edismax implementation it provides a more fine-grained control over the combination of the sub-scores that result from pf/pf2/pf3 subqueries.

For example: 

    pf=field1 field2
    pf2=field1 field2
    pf3=field1 field2
    q=a b c d

Standard Solr (BQ - BooleanQuery, DMQ - DismaxQuery):

    BQ(
      field1:"a b c d", field2:"a b c d", 
      field1:"a b", field1:"b c", field1:"c d", field2:"a b", field2:"b c", field2:"c d", 
      field1:"a b c", field1:"b c d", field2:"a b c", field2:"b c d"
    )

bmax:

    DMQ(
      DMQ(field1:"a b c d", field2:"a b c d"),
      DMQ(
        BQ(field1:"a b", field1:"b c", field1:"c d"), 
        BQ(field2:"a b", field2:"b c", field2:"c d")
      ),
      DMQ(
        BQ(field1:"a b c", field1:"b c d")
        BQ(field2:"a b c", field2:"b c d")
      )
    )

You can set phrase.tie=1.0 to simulate the standard Solr behaviour for bmax. The idea behind using a dismax query instead of a BooleanQuery is prevent scores for pf, pf2 and pf3 to sum up for the same match as pf matches always imply matches for pf2, and possibly for pf3.


