### PR TITLE
Add toggle for returning MatchNoDocsQuery in case of no query terms

### DIFF
--- a/src/main/java/com/s24/search/solr/query/bmax/BmaxQueryParser.java
+++ b/src/main/java/com/s24/search/solr/query/bmax/BmaxQueryParser.java
@@ -1,13 +1,14 @@
 package com.s24.search.solr.query.bmax;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map.Entry;
-
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Iterables;
+import com.s24.search.solr.query.bmax.BmaxQuery.BmaxTerm;
+import com.s24.search.solr.util.BmaxDebugInfo;
+import eu.danieldk.dictomaton.DictionaryBuilder;
+import eu.danieldk.dictomaton.DictionaryBuilderException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.Query;
@@ -25,16 +26,13 @@ import org.apache.solr.util.SolrPluginUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Iterables;
-import com.s24.search.solr.query.bmax.BmaxQuery.BmaxTerm;
-import com.s24.search.solr.util.BmaxDebugInfo;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
 
-import eu.danieldk.dictomaton.DictionaryBuilder;
-import eu.danieldk.dictomaton.DictionaryBuilderException;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class BmaxQueryParser extends ExtendedDismaxQParser {
 
@@ -49,6 +47,7 @@ public class BmaxQueryParser extends ExtendedDismaxQParser {
    public static final String PARAM_INSPECT_TERMS = "bmax.inspect";
    public static final String PARAM_BUILD_INSPECT_TERMS = "bmax.inspect.build";
    public static final String PARAM_PHRASE_BOOST_TIE = "phrase.tie";
+   public static final String PARAM_ENABLE_MATCH_NO_DOCS_QUERY_FOR_NO_TERMS = "bmax.no.docs";
 
    private static final String WILDCARD = "*:*";
 
@@ -130,6 +129,7 @@ public class BmaxQueryParser extends ExtendedDismaxQParser {
             .withBoostQueries(getBoostQueries())
             .withSchema(getReq().getSchema())
             .withFieldTermCache(fieldTermCache)
+            .withNoMatchDocsForNoTermsQuery(params.getBool(PARAM_ENABLE_MATCH_NO_DOCS_QUERY_FOR_NO_TERMS, false))
             .build();
 
       // save debug stuff

--- a/src/test/java/com/s24/search/solr/query/bmax/BmaxLuceneQueryBuilderTest.java
+++ b/src/test/java/com/s24/search/solr/query/bmax/BmaxLuceneQueryBuilderTest.java
@@ -1,20 +1,8 @@
 package com.s24.search.solr.query.bmax;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
-import static com.s24.search.solr.query.bmax.AbstractLuceneQueryTest.*;
-
 import com.s24.search.solr.query.bmax.BmaxQuery.BmaxTerm;
-
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.DisjunctionMaxQuery;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
+import org.apache.lucene.search.*;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
@@ -26,6 +14,11 @@ import org.mockito.Mockito;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.s24.search.solr.query.bmax.AbstractLuceneQueryTest.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 public class BmaxLuceneQueryBuilderTest {
 
@@ -55,7 +48,25 @@ public class BmaxLuceneQueryBuilderTest {
             .build();
 
       assertEquals(new MatchAllDocsQuery(), buildedQuery);
+   }
 
+   @Test
+   public void testMatchNoDocsQueryForNoTerms() {
+      // given
+      BmaxQuery bmaxQuery = new BmaxQuery();
+
+
+      // when
+      Query result1 = new BmaxLuceneQueryBuilder(bmaxQuery)
+              .withNoMatchDocsForNoTermsQuery(true)
+              .build();
+
+      Query result2 = new BmaxLuceneQueryBuilder(bmaxQuery)
+              .build();
+
+      // then
+      assertThat(result1, instanceOf(MatchNoDocsQuery.class));
+      assertThat(result2, instanceOf(MatchAllDocsQuery.class));
    }
 
    @Test


### PR DESCRIPTION
Passing 'bmax.no.docs = true' as a solr parameter will produce a MatchNoDocsQuery rather than a MatchAllDocsQuery in case there are no query terms set. This might be useful if you want to present no result at all instead of a potentially expensive match all query. A usecase for this are searches that contain only stopwords